### PR TITLE
Shop Zone check

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -212,6 +212,7 @@ CreateThread(function()
                 Listen4Control()
             else
                 exports["qb-core"]:HideText()
+                listen = false
             end
         end)
 


### PR DESCRIPTION
Issue was reported here https://github.com/qbcore-framework/qb-shops/issues/81

Basically if you leave the shop zones when you don't interact with it... You can still open the shops.... Anywhere..

HotFix