### PR TITLE
missing blipscale

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -438,6 +438,7 @@ Config.Locations = {
         ["products"] = Config.Products["normal"],
         ["showblip"] = true,
         ["blipsprite"] = 52,
+        ["blipscale"] = 0.6,
         ["blipcolor"] = 0
     },
 


### PR DESCRIPTION
added       ["blipscale"] = 0.6,

**Describe Pull request**
BLIP IS NOT SHOWING BECAUSE THERE IS MISSING OF BLIP SCALE


If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] - 
- YES
- Does your code fit the style guidelines? [yes/no] 
- YES
- Does your PR fit the contribution guidelines? [yes/no]
- YES
