### PR TITLE
Grant weapon license issue for shop

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -76,7 +76,8 @@ local function openShop(shop, data)
     local ShopItems = {}
     ShopItems.items = {}
     ShopItems.label = data["label"]
-
+    local PlayerData = QBCore.Functions.GetPlayerData()
+    
     if data.type == "weapon" and Config.FirearmsLicenseCheck then
         if PlayerData.metadata["licences"].weapon and QBCore.Functions.HasItem("weaponlicense") then
             ShopItems.items = SetupItems(shop)


### PR DESCRIPTION
The shop doesnt grab the new playerdata after granting the license player needs to relog so the shop gets the new data onplayerload this solves this issue

full description is here #117 