### PR TITLE
licences spelling fix, which leads to the issue of licence check

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -78,7 +78,7 @@ local function openShop(shop, data)
     ShopItems.label = data["label"]
 
     if data.type == "weapon" and Config.FirearmsLicenseCheck then
-        if PlayerData.metadata['licenses'] and PlayerData.metadata["licences"].weapon and QBCore.Functions.HasItem("weaponlicense") then
+        if PlayerData.metadata['licences'] and PlayerData.metadata["licences"].weapon and QBCore.Functions.HasItem("weaponlicense") then
             ShopItems.items = SetupItems(shop)
             QBCore.Functions.Notify(Lang:t("success.dealer_verify"), "success")
             Wait(500)


### PR DESCRIPTION
**Describe Pull request**
spelling mistake of licences in client.lua , which leads to an issue of firearm dealer refuses to show weapons even if the player has the licence

If your PR is to fix an issue mention that issue here
fixing issue  #125

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest) 
- yes
- Does your code fit the style guidelines? [yes/no]
- yes
- Does your PR fit the contribution guidelines? [yes/no]
- yes
