### PR TITLE
Update; SoW Location

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -967,7 +967,7 @@ Config.Locations = {
     -- Weedshop Locations
     ["weedshop"] = {
         ["label"] = "Smoke On The Water",
-        ["coords"] = vector4(-1171.31, -1570.89, 4.66, 130.03),
+        ["coords"] = vector4(-1168.26, -1573.2, 4.66, 105.24),
         ["ped"] = 'a_m_y_hippy_01',
         ["scenario"] = "WORLD_HUMAN_AA_SMOKE",
         ["radius"] = 1.5,


### PR DESCRIPTION
Smoke on Water Ped, When using QB-Target, wont allows you to interact. Moved ped to side of the counter, meaning he is now interactable. 

This moves for non qb-target too. To have two seprate locations depending on target config, whilst possible, will result in a less clean code on the client lua. Therefore, I have moved the ped instead.

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
