### PR TITLE
Address server sever event spam when a client enters a shop poly

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -102,8 +102,8 @@ local function listenForControl()
     CreateThread(function()
         listen = true
         while listen do
-            TriggerServerEvent('qb-shops:server:SetShopList')
             if IsControlJustPressed(0, 38) then -- E
+            TriggerServerEvent('qb-shops:server:SetShopList')
                 if inChips then
                     exports["qb-core"]:KeyPressed()
                     TriggerServerEvent("qb-shops:server:sellChips")

--- a/client/main.lua
+++ b/client/main.lua
@@ -103,7 +103,7 @@ local function listenForControl()
         listen = true
         while listen do
             if IsControlJustPressed(0, 38) then -- E
-            TriggerServerEvent('qb-shops:server:SetShopList')
+                TriggerServerEvent('qb-shops:server:SetShopList')
                 if inChips then
                     exports["qb-core"]:KeyPressed()
                     TriggerServerEvent("qb-shops:server:sellChips")

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'QB-Shops'
-version '1.2.0'
+version '1.2.1'
 
 shared_scripts {
     '@PolyZone/client.lua',


### PR DESCRIPTION
**Describe Pull request**
Don't update the shop list until the client presses E while in the shop poly.
(Original code causes client disconnects due to network overflows and breaks store robberies)

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest) Yes
- Does your code fit the style guidelines? [yes/no] Yes
- Does your PR fit the contribution guidelines? [yes/no] Yes
