### PR TITLE
fix(shops): Sell casino chips

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -269,6 +269,7 @@ if not Config.UseTarget then
             if isPointInside then
                 inChips = true
                 exports["qb-core"]:DrawText(Lang:t("info.sell_chips"))
+                listenForControl()
             else
                 inChips = false
                 exports["qb-core"]:HideText()


### PR DESCRIPTION
Fix unable to sell casino chips when using drawtext.

Addresses issues #135  #137 